### PR TITLE
Bump version number to 3.0.0.548

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM mono:5
 
 ENV S6_VERSION=v1.21.4.0
 ENV LANG=en_US.UTF-8
-ENV HOMESEER_VERSION=3_0_0_500
+ENV HOMESEER_VERSION=3_0_0_531
 
 RUN apt-get update && apt-get install -y \
     chromium \
@@ -34,7 +34,7 @@ COPY rootfs /
 ARG AVAHI
 RUN [ "${AVAHI:-1}" = "1" ] || (echo "Removing Avahi" && rm -rf /etc/services.d/avahi /etc/services.d/dbus)
 
-VOLUME [ "/HomeSeer" ] 
+VOLUME [ "/HomeSeer" ]
 EXPOSE 80 10200 10300 10401
 
 ENTRYPOINT [ "/init" ]

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This image containerizes the HomeSeer HS3 home automation software. 
 
-Current HomeSeer version: **HS3 3.0.0.500**
+Current HomeSeer version: **HS3 3.0.0.531**
 
 ### Running the HomeSeer Container
 
@@ -65,6 +65,7 @@ To contribute, please fork the GitHub repo, create a feature branch, and raise a
 This image was inspired by @marthoc's HomeSeer image (on Docker Hub at marthoc/homeseer)
 
 ### Changelog
-7 February 2019 Updated to version 3.0.0.500
-9 January 2019: Added Etherwake,SSH-Client and updated to HS3 Version - 3.0.0.478
-12 December 2018: Initial update release.
++ 17 May 2019 Updated to Version 3.0.0.531
++ 7 February 2019 Updated to version 3.0.0.500
++ 9 January 2019: Added Etherwake,SSH-Client and updated to HS3 Version - 3.0.0.478
++ 12 December 2018: Initial update release.


### PR DESCRIPTION
Bump the HS Version number to 3.0.0.531

3.0.0.531 was released 2019-04-16.

Changelog from HomeSeer:

+ Added support to add our new HS cameras using HS Mobile
+ Fixed JSON command setdevicestatus could not set a value of 0
+ Added a "compress" option to JSON command getstatus to speed up HS Mobile
+ Added a new "getsessionconfig" to get permission info
+ Fixed voice command "set device to # percent"
+ Control Use options can not be set on status pairs (needed for future Alexa updates)
+ Backup now includes html folder
+ Fixed global conditions not working with plugins
+ Fixed unable to add "Or If" to a global condition
+ Fixed remote plugins did not display proper license
+ Devices no longer display "Dim" as a status if no status pairs have been added
+ Devices not longer display ON/OFF buttons by default if no control pairs are added
+ Parent/Child relationships are checked on startup and issues logged as warning
+ The Labs tab in setup has a new button to fix broken parent/child relationships (should fix HS Mobile issues with devices)
+ Event list now has a disabled icon if an event is disabled (some users could not see the red color)
+ Fixed events in HS Mobile not honoring the user access setting for users in HS